### PR TITLE
Add fmodwasm & example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,8 @@ color-eyre = "0.6.3"
 glam = "0.29.2"
 libfmod = "2.222.6"
 u64-id = "0.1.0"
+getrandom = { version = "0.2.15", features = ["js"] }
+wasm-bindgen = "0.2.99"
+bitflags = { version = "2.6.0" }
+console_error_panic_hook = "0.1.7"
+web-sys = { version = "0.3.76", features = ["Window", "console"] }

--- a/TEMP_README.md
+++ b/TEMP_README.md
@@ -1,0 +1,46 @@
+This is a temporary README for the purpose of explaining how one can run the
+example.
+
+# Project structure
+`/wasm` is where handwritten JS binding code resides.
+`/example` is example that can run in web with missing FMOD Emscripten module.
+`/resources` is dir for binary assets, these are included with include_bytes!().
+`/src/main.rs` is the binary example that can run in both WASM and native.
+`/src/wasmfmod.rs` is where functions that call WASM and all that stuff resides.
+
+# How to run the example
+*NOTE:* I only tried it on Windows as that's what I have access to (my PC).
+*NOTE:* I also used FMOD Studio's example for the purposes of testing this.
+
+- Put FMOD assets you want in `/resources`.
+- Update `/src/main.rs` with assets added.
+- Get FMOD's dev libraries as described as here:
+  https://github.com/lebedec/libfmod?tab=readme-ov-file#fmod-development-libraries
+- Also get FMOD Engine's HTML5 bindings. These will be copied from
+  `api/core/lib/upstream/wasm` and `api/studio/lib/upstream/wasm` into
+  `/example/third_party_deps`. Download link for this can be found here:
+  https://www.fmod.com/download#fmodengine
+- Build repo with with wasm32-unknown-unknown target:
+  `cargo build --target wasm32-unknown-unknown`
+- Install wasm-bindgen-cl:
+  https://rustwasm.github.io/wasm-bindgen/reference/cli.html
+- Run wasm-bindgen like so:
+  `wasm-bindgen target\wasm32-unknown-unknown\debug\fmod-test-bed.wasm --target no-modules --out-dir example/deps`
+- Copy `wasm\wasmfmod.js` to `example\deps\wasmfmod.js`. This isn't a generated
+  file, but it isn't possible to serve for testing purposes that can acccess
+  server FS from `../`.
+- Serve the folder example with some quick serve thing like basic-http-server.
+  In case of basic-http-server, it is simple as `basic-http-server example`.
+- Load the link in the browser. It requires a click interaction to start.
+  I think this is related to FMOD, idk if it can be disabled or not. (or)
+  if it is worth the hassle.
+
+
+# Batch script I used as an example to recompile & execute WASM stuff
+```batch
+cargo build --target wasm32-unknown-unknown
+wasm-bindgen target\wasm32-unknown-unknown\debug\fmod-test-bed.wasm --target no-modules --out-dir example/deps
+copy target\wasm32-unknown-unknown\debug\fmod-test-bed.wasm example\deps\fmod-test-bed.wasm
+copy wasm\wasmfmod.js example\deps\wasmfmod.js
+basic-http-server example
+```

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,36 @@
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title>Sample</title>
+    <style>
+        html,
+        body,
+        canvas {
+            margin: 0px;
+            padding: 0px;
+            width: 100%;
+            height: 100%;
+            overflow: hidden;
+            position: absolute;
+            background: black;
+            z-index: 0;
+        }
+    </style>
+</head>
+
+<body>
+    <canvas id="glcanvas" tabindex='1'></canvas>
+    <script src="third_party_deps/fmod.js"></script>
+    <script src="third_party_deps/fmodstudio.js"></script>
+	<script src="deps/fmod-test-bed.js"></script>
+	<script>
+		async function run() {
+			await wasm_bindgen();
+		}
+		run();
+	</script>
+	<script src="deps/wasmfmod.js"></script>
+</body>
+
+</html>

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,323 @@
+use std::{
+    cell::{RefCell, RefMut},
+    rc::Rc,
+};
+
+use fmod_test_bed::{AudioEngine, EventInstance};
+use u64_id::U64Id;
+
+#[cfg(target_arch = "wasm32")]
+macro_rules! agnostic_print {
+    ($($t:tt)*) => (web_sys::console::log_1(&format_args!($($t)*).to_string().into()))
+}
+
+#[cfg(target_arch = "x86_64")]
+macro_rules! agnostic_print {
+    ($($t:tt)*) => (println!("{}", format_args!($($t)*)))
+}
+
+// Wasm "loop", it uses requestAnimationFrame from browser window to run in a
+// good refresh rate. Changing tabs makes it slower, so audio starts to cut
+// for that reason.
+#[cfg(target_arch = "wasm32")]
+pub fn main() -> Result<(), wasm_bindgen::JsValue> {
+    use std::panic;
+    use wasm_bindgen::prelude::*;
+
+    // In case some panic occurs at Rust side, this allows it to log into
+    // console instead of some vague error.
+    panic::set_hook(Box::new(console_error_panic_hook::hook));
+    let engine = Rc::new(RefCell::new(setup()));
+
+    // :(
+    let closure: Rc<RefCell<Option<Closure<dyn FnMut()>>>> = Rc::new(RefCell::new(None));
+    let self_closure = closure.clone();
+
+    *closure.borrow_mut() = Some(Closure::new(move || {
+        if !tick(engine.borrow_mut()) {
+            return;
+        }
+        web_sys::window()
+            .unwrap()
+            .request_animation_frame(
+                self_closure
+                    .borrow()
+                    .as_ref()
+                    .unwrap()
+                    .as_ref()
+                    .unchecked_ref(),
+            )
+            .unwrap();
+    }));
+
+    web_sys::window()
+        .unwrap()
+        .request_animation_frame(closure.borrow().as_ref().unwrap().as_ref().unchecked_ref())
+        .unwrap();
+
+    Ok(())
+}
+
+struct Game {
+    tick_count: u32,
+    engine: AudioEngine,
+    current: Option<EventInstance>,
+}
+
+// Native loop. Uses Rc<RefCell>> because tick has to, because of the closure
+// above in wasm main.
+#[cfg(target_arch = "x86_64")]
+pub fn main() {
+    let engine = Rc::new(RefCell::new(setup()));
+
+    while tick(engine.borrow_mut()) {
+        std::thread::sleep(std::time::Duration::from_secs_f64(1. / 144.));
+    }
+}
+
+// Shared setup code
+fn setup() -> Game {
+    agnostic_print!("- AudioEngine::new()");
+    let mut engine = AudioEngine::new(true).unwrap();
+
+    let master_strings_bank = include_bytes!("../resources/Master.strings.bank");
+    let master_bank = include_bytes!("../resources/Master.bank");
+    let music_bank = include_bytes!("../resources/Music.bank");
+
+    agnostic_print!("- AudioEngine::load_bank_files_from_memory()");
+    engine
+        .load_bank_files_from_memory(
+            U64Id::new(),
+            &[master_strings_bank, master_bank, music_bank],
+        )
+        .unwrap();
+
+    Game {
+        tick_count: 0,
+        engine,
+        current: None,
+    }
+}
+// Shared tick code
+fn tick(mut game: RefMut<Game>) -> bool {
+    let mut check_tick = 0;
+    let mut next_check = || {
+        check_tick += 144;
+        check_tick
+    };
+
+    if game.tick_count == next_check() {
+        agnostic_print!(
+            "- AudioEngine::event_names() -> {:?}",
+            game.engine.event_names()
+        );
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("- AudioEngine::play_event(\"event:/Music/Level 02\")");
+        game.current = game.engine.play_event("event:/Music/Level 02").ok();
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("- AudioEngine::set_global_mute(true)");
+        game.engine.set_global_mute(true);
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("- AudioEngine::set_global_mute(false)");
+        game.engine.set_global_mute(false);
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!(
+            "- AudioEngine::is_event_playing(\"event:/Music/Level 02\") -> {:?}",
+            game.engine.is_event_playing("event:/Music/Level 02"),
+        );
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!(
+            "- AudioEngine::event_instance_count(\"event:/Music/Level 02\") -> {:?}",
+            game.engine.event_instance_count("event:/Music/Level 02"),
+        );
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("- AudioEngine::set_global_parameter(\"Area\", 70.0) !! This one doesn't work with example because
+            I don't know how to use FMOD :(");
+        game.engine.set_global_parameter("Area", 70.0).ok();
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!(
+            "- AudioEngine::set_listener_position_velocity((15.0, 15.0).into(), (5.0, 5.0).into())"
+        );
+        game.engine
+            .set_listener_position_velocity((15.0, 15.0).into(), (5.0, 5.0).into())
+            .ok();
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("---");
+        agnostic_print!(
+            "- AudioEngine::listener_position() -> {:?}",
+            game.engine.listener_position()
+        );
+        agnostic_print!(
+            "- AudioEngine::listener_position() -> {:?}",
+            game.engine.listener_velocity()
+        );
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("- EventInstance::set_pitch(1.5)");
+        game.current.as_ref().unwrap().set_pitch(1.5).unwrap();
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("---");
+        agnostic_print!(
+            "- EventInstance::pitch() -> {:?}",
+            game.current.as_ref().unwrap().pitch(),
+        );
+        agnostic_print!(
+            "- EventInstance::final_pitch() -> {:?}",
+            game.current.as_ref().unwrap().final_pitch()
+        );
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("- EventInstance::set_pitch(1.0)");
+        game.current.as_ref().unwrap().set_pitch(1.0).unwrap();
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("- EventInstance::set_volume(0.25)");
+        game.current.as_ref().unwrap().set_volume(0.25).unwrap();
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("---");
+        agnostic_print!(
+            "- EventInstance::volume() -> {:?}",
+            game.current.as_ref().unwrap().volume(),
+        );
+        agnostic_print!(
+            "- EventInstance::final_volume() -> {:?}",
+            game.current.as_ref().unwrap().final_volume(),
+        );
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("- EventInstance::set_volume(1.0)");
+        game.current.as_ref().unwrap().set_volume(1.0).unwrap();
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("- EventInstance::pause()");
+        game.current.as_ref().unwrap().pause().unwrap();
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!(
+            "- EventInstance::is_paused() -> {:?}",
+            game.current.as_ref().unwrap().is_paused(),
+        );
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("- EventInstance::unpause()");
+        game.current.as_ref().unwrap().unpause().unwrap();
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("- EventInstance::set_timeline_position(5000)");
+        game.current
+            .as_ref()
+            .unwrap()
+            .set_timeline_position(5000)
+            .unwrap();
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!(
+            "- EventInstance::timeline_position() -> {:?}",
+            game.current.as_ref().unwrap().timeline_position(),
+        );
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!(
+            "- EventInstance::is_virtual() -> {:?}",
+            game.current.as_ref().unwrap().is_virtual(),
+        );
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("- EventInstance::stop()");
+        game.current.as_ref().unwrap().stop().unwrap();
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!(
+            "- EventInstance::playback_state() -> {:?}",
+            game.current.as_ref().unwrap().playback_state(),
+        );
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("- EventInstance::start()");
+        game.current.as_ref().unwrap().start().unwrap();
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("- EventInstance::set_property(ScheduleDelay, 1.0)");
+        game.current
+            .as_ref()
+            .unwrap()
+            .set_property(fmod_test_bed::EventProperty::ScheduleDelay, 1.0)
+            .unwrap();
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!(
+            "- EventInstance::property(ScheduleDelay) -> {:?}",
+            game.current
+                .as_ref()
+                .unwrap()
+                .property(fmod_test_bed::EventProperty::ScheduleDelay),
+        );
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("- EventInstance::set_parameter_by_name(\"Area\", 70.0, false)");
+        game.current
+            .as_ref()
+            .unwrap()
+            .set_parameter_by_name("Area", 70.0, false)
+            .unwrap();
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("---");
+        agnostic_print!(
+            "- EventInstance::get_parameter_by_name(\"Area\") -> {:?}",
+            game.current.as_ref().unwrap().get_parameter_by_name("Area"),
+        );
+        agnostic_print!(
+            "- EventInstance::get_final_parameter_by_name(\"Area\") -> {:?}",
+            game.current
+                .as_ref()
+                .unwrap()
+                .get_final_parameter_by_name("Area"),
+        );
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!(
+            "- EventInstance::set_position_velocity((2.0, 2.0).into(), (4.0, 4.0).into())"
+        );
+        game.current
+            .as_ref()
+            .unwrap()
+            .set_position_velocity((2.0, 2.0).into(), (4.0, 4.0).into())
+            .unwrap();
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!(
+            "- EventInstance::get_position_velocity() -> {:?}",
+            game.current.as_ref().unwrap().get_position_velocity()
+        );
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("- EventInstance::mark_for_release()");
+        game.current.as_ref().unwrap().mark_for_release().unwrap();
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("- EventInstance::stop_immediately()");
+        game.current.as_ref().unwrap().stop_immediately().unwrap();
+    }
+    if game.tick_count == next_check() {
+        agnostic_print!("- EventInstance::unload_banks()");
+        game.engine.unload_banks();
+
+        return false;
+    }
+
+    game.engine.update().unwrap();
+    game.tick_count += 1;
+
+    true
+}

--- a/src/wasmfmod.rs
+++ b/src/wasmfmod.rs
@@ -1,0 +1,901 @@
+///
+/// This is libfmod replacement for WASM with limited functionality, where it
+/// is almost 1:1. Anything that includes opaque JsValue is not Copy, so that's
+/// one difference between libfmod and this. JsValue is actually a 32bit number
+/// , so this can be solved by transmuting I read somewhere. But, I kept it as
+/// like this for now. If lack of Copy is too much of an issue, it is a quick
+/// change, at least feels like one.
+use std::{
+    ffi::{c_void, IntoStringError, NulError},
+    fmt::{Display, Formatter},
+};
+
+use wasm_bindgen::prelude::*;
+
+use bitflags::bitflags;
+
+macro_rules! err_fmod {
+    ($ function : expr , $ code : expr) => {
+        Error::Fmod {
+            function: $function.to_string(),
+            code: $code as i32,
+            message: "".to_string(),
+        }
+    };
+}
+
+// Studio wrapper and binding
+#[derive(Debug, Clone)]
+pub struct Studio {
+    opaque: JsValue,
+}
+impl Studio {
+    pub fn create() -> Result<Self, Error> {
+        let result = Studio_System_Create();
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(Self { opaque: result.1 }),
+            err => Err(err_fmod!("Studio_System_Create", err)),
+        }
+    }
+    pub fn initialize(
+        &self,
+        max_channels: i32,
+        studio_flags: StudioInit,
+        flags: Init,
+        // I don't know whether extra_driver_data works or not and I don't
+        // know how to test it. But my gut feeling says this probably won't
+        // work. This one probably needs to be created on Emscripten side.
+        extra_driver_data: Option<*mut c_void>,
+    ) -> Result<(), Error> {
+        let result = Studio_System_Initialize(
+            &self.opaque,
+            max_channels,
+            studio_flags.bits(),
+            flags.bits(),
+            extra_driver_data,
+        );
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(()),
+            err => Err(err_fmod!("Studio_System_Initialize", err)),
+        }
+    }
+
+    pub fn load_bank_memory(&self, buffer: &[u8], flags: LoadBank) -> Result<Bank, Error> {
+        let result = Studio_System_LoadBankMemory(&self.opaque, buffer, flags.bits());
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(Bank { opaque: result.1 }),
+            err => Err(err_fmod!("Studio_System_LoadBankMemory", err)),
+        }
+    }
+    pub fn unload_all(&self) -> Result<(), Error> {
+        let result = Studio_System_UnloadAll(&self.opaque);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(()),
+            err => Err(err_fmod!("Studio_System_UnloadAll", err)),
+        }
+    }
+    pub fn get_event(&self, path_or_id: &str) -> Result<EventDescription, Error> {
+        let result = Studio_System_GetEvent(&self.opaque, path_or_id);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(EventDescription { opaque: result.1 }),
+            err => Err(err_fmod!("Studio_System_GetEvent", err)),
+        }
+    }
+    pub fn get_bus(&self, path_or_id: &str) -> Result<Bus, Error> {
+        let result = Studio_System_GetBus(&self.opaque, path_or_id);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(Bus { opaque: result.1 }),
+            err => Err(err_fmod!("Studio_System_GetBus", err)),
+        }
+    }
+    pub fn set_parameter_by_name(
+        &self,
+        name: &str,
+        value: f32,
+        ignore_seek_speed: bool,
+    ) -> Result<(), Error> {
+        let result = Studio_System_SetParameterByName(&self.opaque, name, value, ignore_seek_speed);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(()),
+            err => Err(err_fmod!("Studio_System_SetParameterByName", err)),
+        }
+    }
+    pub fn set_listener_attributes(
+        &self,
+        index: i32,
+        attributes: Attributes3d,
+        attenuation_position: Option<Vector>,
+    ) -> Result<(), Error> {
+        let result = Studio_System_SetListenerAttributes(
+            &self.opaque,
+            index,
+            Attributes3d::from(attributes),
+            attenuation_position.map(Vector::from),
+        );
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(()),
+            err => Err(err_fmod!("Studio_System_Update", err)),
+        }
+    }
+    pub fn update(&self) -> Result<(), Error> {
+        let result = Studio_System_Update(&self.opaque);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(()),
+            err => Err(err_fmod!("Studio_System_Update", err)),
+        }
+    }
+}
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen]
+    fn Studio_System_Create() -> JsValueJSResult;
+    #[wasm_bindgen]
+    fn Studio_System_Initialize(
+        studio: &JsValue,
+        max_channels: i32,
+        studio_flags: u32,
+        flags: u32,
+        extra_driver_data: Option<*mut c_void>,
+    ) -> JSResult;
+    #[wasm_bindgen]
+    fn Studio_System_LoadBankMemory(studio: &JsValue, buffer: &[u8], flags: u32)
+        -> JsValueJSResult;
+    #[wasm_bindgen]
+    fn Studio_System_UnloadAll(studio: &JsValue) -> JSResult;
+    #[wasm_bindgen]
+    fn Studio_System_GetEvent(studio: &JsValue, path: &str) -> JsValueJSResult;
+    #[wasm_bindgen]
+    fn Studio_System_GetBus(studio: &JsValue, path: &str) -> JsValueJSResult;
+    #[wasm_bindgen]
+    fn Studio_System_SetParameterByName(
+        studio: &JsValue,
+        name: &str,
+        value: f32,
+        ignore_seek_speed: bool,
+    ) -> JSResult;
+    #[wasm_bindgen]
+    fn Studio_System_SetListenerAttributes(
+        studio: &JsValue,
+        index: i32,
+        attributes: Attributes3d,
+        attenuation_position: Option<Vector>,
+    ) -> JSResult;
+    #[wasm_bindgen]
+    fn Studio_System_Update(studio: &JsValue) -> JSResult;
+}
+
+// Bank wrapper and binding
+#[derive(Debug, Clone)]
+pub struct Bank {
+    opaque: JsValue,
+}
+impl Bank {
+    pub fn get_event_list(&self, capacity: i32) -> Result<Vec<EventDescription>, Error> {
+        let result = Studio_Bank_GetEventList(&self.opaque, capacity);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(result
+                .1
+                .into_iter()
+                .map(|opaque| EventDescription { opaque })
+                .collect()),
+            err => Err(err_fmod!("Studio_Bank_GetEventList", err)),
+        }
+    }
+    pub fn get_event_count(&self) -> Result<i32, Error> {
+        let result = Studio_Bank_GetEventCount(&self.opaque);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(result.1),
+            err => Err(err_fmod!("Studio_Bank_GetEventCount", err)),
+        }
+    }
+}
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen]
+    fn Studio_Bank_GetEventList(bank: &JsValue, capacity: i32) -> JsValueVecJSResult;
+    #[wasm_bindgen]
+    fn Studio_Bank_GetEventCount(bank: &JsValue) -> I32JSResult;
+}
+
+// EventDescription wrapper and binding
+#[derive(Debug, Clone)]
+pub struct EventDescription {
+    opaque: JsValue,
+}
+impl EventDescription {
+    pub fn get_path(&self) -> Result<String, Error> {
+        let result = Studio_EventDescription_GetPath(&self.opaque);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(result.1),
+            err => Err(err_fmod!("Studio_EventDescription_GetPath", err)),
+        }
+    }
+    pub fn create_instance(&self) -> Result<EventInstance, Error> {
+        let result = Studio_EventDescription_CreateInstance(&self.opaque);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(EventInstance { opaque: result.1 }),
+            err => Err(err_fmod!("Studio_EventDescription_CreateInstance", err)),
+        }
+    }
+    pub fn get_instance_count(&self) -> Result<i32, Error> {
+        let result = Studio_EventDescription_GetInstanceCount(&self.opaque);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(result.1),
+            err => Err(err_fmod!("Studio_EventDescription_GetInstanceCount", err)),
+        }
+    }
+}
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen]
+    fn Studio_EventDescription_GetPath(description: &JsValue) -> StringJSResult;
+    #[wasm_bindgen]
+    fn Studio_EventDescription_CreateInstance(description: &JsValue) -> JsValueJSResult;
+    #[wasm_bindgen]
+    fn Studio_EventDescription_GetInstanceCount(description: &JsValue) -> I32JSResult;
+}
+
+// EventInstance wrapper and binding
+#[derive(Debug, Clone)]
+pub struct EventInstance {
+    opaque: JsValue,
+}
+impl EventInstance {
+    pub fn start(&self) -> Result<(), Error> {
+        let result = Studio_EventInstance_Start(&self.opaque);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(()),
+            err => Err(err_fmod!("Studio_EventInstance_Start", err)),
+        }
+    }
+    pub fn release(&self) -> Result<(), Error> {
+        let result = Studio_EventInstance_Release(&self.opaque);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(()),
+            err => Err(err_fmod!("Studio_EventInstance_Release", err)),
+        }
+    }
+    pub fn get_3d_attributes(&self) -> Result<Attributes3d, Error> {
+        let result = Studio_EventInstance_Get3DAttributes(&self.opaque);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(Attributes3d::from(result.1)),
+            err => Err(err_fmod!("Studio_EventInstance_Get3DAttributes", err)),
+        }
+    }
+    pub fn set_3d_attributes(&self, attributes: Attributes3d) -> Result<(), Error> {
+        let result =
+            Studio_EventInstance_Set3DAttributes(&self.opaque, Attributes3d::from(attributes));
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(()),
+            err => Err(err_fmod!("Studio_EventInstance_Set3DAttributes", err)),
+        }
+    }
+    pub fn get_pitch(&self) -> Result<(f32, f32), Error> {
+        let result = Studio_EventInstance_GetPitch(&self.opaque);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok((result.1, result.2)),
+            err => Err(err_fmod!("Studio_EventInstance_GetPitch", err)),
+        }
+    }
+    pub fn set_pitch(&self, pitch: f32) -> Result<(), Error> {
+        let result = Studio_EventInstance_SetPitch(&self.opaque, pitch);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(()),
+            err => Err(err_fmod!("Studio_EventInstance_SetPitch", err)),
+        }
+    }
+    pub fn get_property(&self, index: EventProperty) -> Result<f32, Error> {
+        let result = Studio_EventInstance_GetProperty(&self.opaque, EventProperty::from(index));
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(result.1),
+            err => Err(err_fmod!("Studio_EventInstance_GetProperty", err)),
+        }
+    }
+    pub fn set_property(&self, index: EventProperty, value: f32) -> Result<(), Error> {
+        let result =
+            Studio_EventInstance_SetProperty(&self.opaque, EventProperty::from(index), value);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(()),
+            err => Err(err_fmod!("Studio_EventInstance_SetProperty", err)),
+        }
+    }
+    pub fn get_timeline_position(&self) -> Result<i32, Error> {
+        let result = Studio_EventInstance_GetTimelinePosition(&self.opaque);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(result.1),
+            err => Err(err_fmod!("Studio_EventInstance_GetTimelinePosition", err)),
+        }
+    }
+    pub fn set_timeline_position(&self, position: i32) -> Result<(), Error> {
+        let result = Studio_EventInstance_SetTimelinePosition(&self.opaque, position);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(()),
+            err => Err(err_fmod!("Studio_EventInstance_SetTimelinePosition", err)),
+        }
+    }
+    pub fn get_volume(&self) -> Result<(f32, f32), Error> {
+        let result = Studio_EventInstance_GetVolume(&self.opaque);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok((result.1, result.2)),
+            err => Err(err_fmod!("Studio_EventInstance_GetVolume", err)),
+        }
+    }
+    pub fn set_volume(&self, volume: f32) -> Result<(), Error> {
+        let result = Studio_EventInstance_SetVolume(&self.opaque, volume);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(()),
+            err => Err(err_fmod!("Studio_EventInstance_SetVolume", err)),
+        }
+    }
+    pub fn is_virtual(&self) -> Result<bool, Error> {
+        let result = Studio_EventInstance_IsVirtual(&self.opaque);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(result.1),
+            err => Err(err_fmod!("Studio_EventInstance_IsVirtual", err)),
+        }
+    }
+    pub fn get_parameter_by_name(&self, name: &str) -> Result<(f32, f32), Error> {
+        let result = Studio_EventInstance_GetParameterByName(&self.opaque, name);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok((result.1, result.2)),
+            err => Err(err_fmod!("Studio_EventInstance_GetParameterByName", err)),
+        }
+    }
+    pub fn set_parameter_by_name(
+        &self,
+        name: &str,
+        value: f32,
+        ignore_seek_speed: bool,
+    ) -> Result<(), Error> {
+        let result =
+            Studio_EventInstance_SetParameterByName(&self.opaque, name, value, ignore_seek_speed);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(()),
+            err => Err(err_fmod!("Studio_EventInstance_SetParameterByName", err)),
+        }
+    }
+    pub fn stop(&self, mode: StopMode) -> Result<(), Error> {
+        let result = Studio_EventInstance_Stop(&self.opaque, StopMode::from(mode));
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(()),
+            err => Err(err_fmod!("Studio_EventInstance_Stop", err)),
+        }
+    }
+    pub fn get_paused(&self) -> Result<bool, Error> {
+        let result = Studio_EventInstance_GetPaused(&self.opaque);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(result.1),
+            err => Err(err_fmod!("Studio_EventInstance_GetPaused", err)),
+        }
+    }
+    pub fn set_paused(&self, paused: bool) -> Result<(), Error> {
+        let result = Studio_EventInstance_SetPaused(&self.opaque, paused);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(()),
+            err => Err(err_fmod!("Studio_EventInstance_SetPaused", err)),
+        }
+    }
+    pub fn get_playback_state(&self) -> Result<PlaybackState, Error> {
+        let result = Studio_EventInstance_GetPlaybackState(&self.opaque);
+        match FMODResult::from(result.0) {
+            FMODResult::Ok => Ok(match result.1 {
+                PlaybackState::Playing => PlaybackState::Playing,
+                PlaybackState::Sustaining => PlaybackState::Sustaining,
+                PlaybackState::Stopped => PlaybackState::Stopped,
+                PlaybackState::Starting => PlaybackState::Starting,
+                PlaybackState::Stopping => PlaybackState::Stopping,
+            }),
+            err => Err(err_fmod!("Studio_EventInstance_GetPitch", err)),
+        }
+    }
+}
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen]
+    fn Studio_EventInstance_Start(instance: &JsValue) -> JSResult;
+    #[wasm_bindgen]
+    fn Studio_EventInstance_Release(instance: &JsValue) -> JSResult;
+    #[wasm_bindgen]
+    fn Studio_EventInstance_Get3DAttributes(instance: &JsValue) -> Attributes3dJSResult;
+    #[wasm_bindgen]
+    fn Studio_EventInstance_Set3DAttributes(
+        instance: &JsValue,
+        attributes: Attributes3d,
+    ) -> JSResult;
+    #[wasm_bindgen]
+    fn Studio_EventInstance_GetPitch(instance: &JsValue) -> F32F32JSResult;
+    #[wasm_bindgen]
+    fn Studio_EventInstance_SetPitch(instance: &JsValue, pitch: f32) -> JSResult;
+    #[wasm_bindgen]
+    fn Studio_EventInstance_GetProperty(instance: &JsValue, index: EventProperty) -> F32JSResult;
+    #[wasm_bindgen]
+    fn Studio_EventInstance_SetProperty(
+        instance: &JsValue,
+        index: EventProperty,
+        value: f32,
+    ) -> JSResult;
+    #[wasm_bindgen]
+    fn Studio_EventInstance_GetTimelinePosition(instance: &JsValue) -> I32JSResult;
+    #[wasm_bindgen]
+    fn Studio_EventInstance_SetTimelinePosition(instance: &JsValue, position: i32) -> JSResult;
+    #[wasm_bindgen]
+    fn Studio_EventInstance_GetVolume(instance: &JsValue) -> F32F32JSResult;
+    #[wasm_bindgen]
+    fn Studio_EventInstance_SetVolume(instance: &JsValue, volume: f32) -> JSResult;
+    #[wasm_bindgen]
+    fn Studio_EventInstance_IsVirtual(instance: &JsValue) -> BoolJSResult;
+    #[wasm_bindgen]
+    fn Studio_EventInstance_GetParameterByName(instance: &JsValue, name: &str) -> F32F32JSResult;
+    #[wasm_bindgen]
+    fn Studio_EventInstance_SetParameterByName(
+        instance: &JsValue,
+        name: &str,
+        value: f32,
+        ignore_seek_speed: bool,
+    ) -> JSResult;
+    #[wasm_bindgen]
+    fn Studio_EventInstance_Stop(instance: &JsValue, stop_mode: StopMode) -> JSResult;
+    #[wasm_bindgen]
+    fn Studio_EventInstance_SetPaused(instance: &JsValue, paused: bool) -> JSResult;
+    #[wasm_bindgen]
+    fn Studio_EventInstance_GetPaused(instance: &JsValue) -> BoolJSResult;
+    #[wasm_bindgen]
+    fn Studio_EventInstance_GetPlaybackState(instance: &JsValue) -> PlaybackStateJSResult;
+}
+
+// Bus wrapper and binding
+#[derive(Debug, Clone)]
+pub struct Bus {
+    opaque: JsValue,
+}
+impl Bus {
+    pub fn set_mute(&self, mute: bool) -> Result<(), ()> {
+        Studio_Bus_SetMute(&self.opaque, mute);
+        Ok(())
+    }
+}
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen]
+    fn Studio_Bus_SetMute(bus: &JsValue, mute: bool);
+}
+
+// Structs, bitflags and enums for libfmod parity
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Vector {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+}
+#[wasm_bindgen]
+impl Vector {
+    #[wasm_bindgen(constructor)]
+    pub fn new(x: f32, y: f32, z: f32) -> Self {
+        Self { x, y, z }
+    }
+}
+impl From<[f32; 3]> for Vector {
+    fn from(value: [f32; 3]) -> Vector {
+        Vector {
+            x: value[0],
+            y: value[1],
+            z: value[2],
+        }
+    }
+}
+impl From<Vector> for [f32; 3] {
+    fn from(value: Vector) -> [f32; 3] {
+        [value.x, value.y, value.z]
+    }
+}
+impl From<(f32, f32, f32)> for Vector {
+    fn from(value: (f32, f32, f32)) -> Vector {
+        Vector {
+            x: value.0,
+            y: value.1,
+            z: value.2,
+        }
+    }
+}
+impl From<Vector> for (f32, f32, f32) {
+    fn from(value: Vector) -> (f32, f32, f32) {
+        (value.x, value.y, value.z)
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Attributes3d {
+    pub position: Vector,
+    pub velocity: Vector,
+    pub forward: Vector,
+    pub up: Vector,
+}
+
+#[wasm_bindgen]
+impl Attributes3d {
+    #[wasm_bindgen(constructor)]
+    pub fn new(position: Vector, velocity: Vector, forward: Vector, up: Vector) -> Self {
+        Self {
+            position,
+            velocity,
+            forward,
+            up,
+        }
+    }
+}
+
+// Enums below are repr(i32) and explicitly annotated with numbers as source of
+// truth for those are not us.
+
+#[wasm_bindgen]
+#[repr(i32)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PlaybackState {
+    Playing = 0,
+    Sustaining = 1,
+    Stopped = 2,
+    Starting = 3,
+    Stopping = 4,
+}
+
+#[wasm_bindgen]
+#[repr(i32)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum EventProperty {
+    ChannelPriority = 0,
+    ScheduleDelay = 1,
+    ScheduleLookahead = 2,
+    MinimumDistance = 3,
+    MaximumDistance = 4,
+    Cooldown = 5,
+    Max = 6,
+}
+
+#[wasm_bindgen]
+#[repr(i32)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum StopMode {
+    AllowFadeout = 0,
+    Immediate = 1,
+}
+
+// Copy of libfmod's Error
+#[derive(Debug)]
+pub enum Error {
+    Fmod {
+        function: String,
+        code: i32,
+        message: String,
+    },
+    EnumBindgen {
+        enumeration: String,
+        value: String,
+    },
+    String(IntoStringError),
+    StringNul(NulError),
+    NotDspFft,
+}
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Fmod {
+                function,
+                code,
+                message,
+            } => {
+                write!(f, "{}: {} ({})", function, message, code)
+            }
+            Error::EnumBindgen { enumeration, value } => {
+                write!(
+                    f,
+                    "FMOD returns unexpected value {} for {} enum",
+                    value, enumeration
+                )
+            }
+            Error::String(_) => {
+                write!(f, "invalid UTF-8 when converting C string")
+            }
+            Error::StringNul(_) => {
+                write!(
+                    f,
+                    "nul byte was found in the middle, C strings can't contain it"
+                )
+            }
+            Error::NotDspFft => {
+                write!(f, "trying get FFT from DSP which not FFT")
+            }
+        }
+    }
+}
+impl std::error::Error for Error {}
+impl From<NulError> for Error {
+    fn from(error: NulError) -> Self {
+        Error::StringNul(error)
+    }
+}
+
+// Copy of bitflags that libfmod provides. Unfortunately, if FMOD changes these
+// these will be updated though. But I guess for that exact reason, FMOD
+// wouldn't make a breaking change on these. This was the best I could come up
+// without making libfmod a dependency.
+bitflags! {
+    pub struct Init: u32 {
+        const NORMAL = 0x00000000;
+        const STREAM_FROM_UPDATE = 0x00000001;
+        const MIX_FROM_UPDATE = 0x00000002;
+        const RIGHTHANDED_3D = 0x00000004;
+        const CLIP_OUTPUT = 0x00000008;
+        const CHANNEL_LOWPASS = 0x00000100;
+        const CHANNEL_DISTANCEFILTER = 0x00000200;
+        const PROFILE_ENABLE = 0x00010000;
+        const VOL0_BECOMES_VIRTUAL = 0x00020000;
+        const GEOMETRY_USECLOSEST = 0x00040000;
+        const PREFER_DOLBY_DOWNMIX = 0x00080000;
+        const THREAD_UNSAFE = 0x00100000;
+        const PROFILE_METER_ALL = 0x00200000;
+        const MEMORY_TRACKING = 0x00400000;
+    }
+    pub struct LoadBank: u32 {
+        const NORMAL = 0x00000000;
+        const NONBLOCKING = 0x00000001;
+        const DECOMPRESS_SAMPLES = 0x00000002;
+        const UNENCRYPTED = 0x00000004;
+    }
+
+    pub struct StudioInit: u32 {
+        const NORMAL = 0x00000000;
+        const LIVEUPDATE = 0x00000001;
+        const ALLOW_MISSING_PLUGINS = 0x00000002;
+        const SYNCHRONOUS_UPDATE = 0x00000004;
+        const DEFERRED_CALLBACKS = 0x00000008;
+        const LOAD_FROM_UPDATE = 0x00000010;
+        const MEMORY_TRACKING = 0x00000020;
+    }
+}
+
+// Same as above, but this is for FMOD's Result enum that functions return
+// when they are called. This is different from libfmod, as I had the lib-
+// erty of creating an actual enum. Maybe I could've gone with wasm-bindgen'ing
+// this too. Or maybe I should use i32 and TryFrom for the above enums too?
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(i32)]
+enum FMODResult {
+    Ok = 0,
+    ErrBadCommand = 1,
+    ErrChannelAlloc = 2,
+    ErrChannelStolen = 3,
+    ErrDMA = 4,
+    ErrDSPConnection = 5,
+    ErrDSPDontProcess = 6,
+    ErrDSPFormat = 7,
+    ErrDSPInUse = 8,
+    ErrDSPNotFound = 9,
+    ErrDSPPReserved = 10,
+    ErrDSPSilence = 11,
+    ErrDSPTtype = 12,
+    ErrFileBad = 13,
+    ErrFileCouldNotSeek = 14,
+    ErrFileDiskEjected = 15,
+    ErrFileEOF = 16,
+    ErrFileEndOfData = 17,
+    ErrFileNotFound = 18,
+    ErrFormat = 19,
+    ErrHeaderMismatch = 20,
+    ErrHTTP = 21,
+    ErrHTTPAccess = 22,
+    ErrHTTPProxyAuth = 23,
+    ErrHTTPServerError = 24,
+    ErrHTTPTimeout = 25,
+    ErrInitialization = 26,
+    ErrInitialized = 27,
+    ErrInternal = 28,
+    ErrInvalidFloat = 29,
+    ErrInvalidHandle = 30,
+    ErrInvalidParam = 31,
+    ErrInvalidPosition = 32,
+    ErrInvalidSpeaker = 33,
+    ErrInvalidSyncPOINT = 34,
+    ErrInvalidThread = 35,
+    ErrInvalidVector = 36,
+    ErrMaxAudible = 37,
+    ErrMemory = 38,
+    ErrMemoryCantPoint = 39,
+    ErrNeeds3D = 40,
+    ErrNeedsHardware = 41,
+    ErrNetConnect = 42,
+    ErrNetSocketError = 43,
+    ErrNetURL = 44,
+    ErrNetWouldBlock = 45,
+    ErrNotReady = 46,
+    ErrOutputAllocated = 47,
+    ErrOutputCreateBuffer = 48,
+    ErrOutputDriverCall = 49,
+    ErrOutputFormat = 50,
+    ErrOutputInit = 51,
+    ErrOutputNoDrivers = 52,
+    ErrPlugin = 53,
+    ErrPluginMissing = 54,
+    ErrPluginResource = 55,
+    ErrPluginVersion = 56,
+    ErrRecord = 57,
+    ErrReverbChannelGroup = 58,
+    ErrReverbInstance = 59,
+    ErrSubsounds = 60,
+    ErrSubsoundAllocated = 61,
+    ErrSubsoundCantMove = 62,
+    ErrTagNotFound = 63,
+    ErrTooManyChannels = 64,
+    ErrTruncated = 65,
+    ErrUnimplemented = 66,
+    ErrUnitialized = 67,
+    ErrUnsupported = 68,
+    ErrVersion = 69,
+    ErrEventAlreadyLoaded = 70,
+    ErrEventLiveUpdateBusy = 71,
+    ErrEventLiveUpdateMismatch = 72,
+    ErrEventLiveUpdateTimeout = 73,
+    ErrEventNotFound = 74,
+    ErrStudioUnitialized = 75,
+    ErrStudioNotLoaded = 76,
+    ErrInvalidString = 77,
+    ErrAlreadyLocked = 78,
+    ErrNotLocked = 79,
+    ErrRecordDisconnected = 80,
+    ErrTooManySamples = 81,
+    /// This is an error code we made up, for the purposes of in case there is
+    /// a mismatch in future.
+    ErrUnknown = 82,
+}
+
+// Rust not giving me choice... Either boilerplate or use some proc macro that
+// generates it. I just copied enum above and edited it with multicursor.
+impl From<i32> for FMODResult {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => FMODResult::Ok,
+            1 => FMODResult::ErrBadCommand,
+            2 => FMODResult::ErrChannelAlloc,
+            3 => FMODResult::ErrChannelStolen,
+            4 => FMODResult::ErrDMA,
+            5 => FMODResult::ErrDSPConnection,
+            6 => FMODResult::ErrDSPDontProcess,
+            7 => FMODResult::ErrDSPFormat,
+            8 => FMODResult::ErrDSPInUse,
+            9 => FMODResult::ErrDSPNotFound,
+            10 => FMODResult::ErrDSPPReserved,
+            11 => FMODResult::ErrDSPSilence,
+            12 => FMODResult::ErrDSPTtype,
+            13 => FMODResult::ErrFileBad,
+            14 => FMODResult::ErrFileCouldNotSeek,
+            15 => FMODResult::ErrFileDiskEjected,
+            16 => FMODResult::ErrFileEOF,
+            17 => FMODResult::ErrFileEndOfData,
+            18 => FMODResult::ErrFileNotFound,
+            19 => FMODResult::ErrFormat,
+            20 => FMODResult::ErrHeaderMismatch,
+            21 => FMODResult::ErrHTTP,
+            22 => FMODResult::ErrHTTPAccess,
+            23 => FMODResult::ErrHTTPProxyAuth,
+            24 => FMODResult::ErrHTTPServerError,
+            25 => FMODResult::ErrHTTPTimeout,
+            26 => FMODResult::ErrInitialization,
+            27 => FMODResult::ErrInitialized,
+            28 => FMODResult::ErrInternal,
+            29 => FMODResult::ErrInvalidFloat,
+            30 => FMODResult::ErrInvalidHandle,
+            31 => FMODResult::ErrInvalidParam,
+            32 => FMODResult::ErrInvalidPosition,
+            33 => FMODResult::ErrInvalidSpeaker,
+            34 => FMODResult::ErrInvalidSyncPOINT,
+            35 => FMODResult::ErrInvalidThread,
+            36 => FMODResult::ErrInvalidVector,
+            37 => FMODResult::ErrMaxAudible,
+            38 => FMODResult::ErrMemory,
+            39 => FMODResult::ErrMemoryCantPoint,
+            40 => FMODResult::ErrNeeds3D,
+            41 => FMODResult::ErrNeedsHardware,
+            42 => FMODResult::ErrNetConnect,
+            43 => FMODResult::ErrNetSocketError,
+            44 => FMODResult::ErrNetURL,
+            45 => FMODResult::ErrNetWouldBlock,
+            46 => FMODResult::ErrNotReady,
+            47 => FMODResult::ErrOutputAllocated,
+            48 => FMODResult::ErrOutputCreateBuffer,
+            49 => FMODResult::ErrOutputDriverCall,
+            50 => FMODResult::ErrOutputFormat,
+            51 => FMODResult::ErrOutputInit,
+            52 => FMODResult::ErrOutputNoDrivers,
+            53 => FMODResult::ErrPlugin,
+            54 => FMODResult::ErrPluginMissing,
+            55 => FMODResult::ErrPluginResource,
+            56 => FMODResult::ErrPluginVersion,
+            57 => FMODResult::ErrRecord,
+            58 => FMODResult::ErrReverbChannelGroup,
+            59 => FMODResult::ErrReverbInstance,
+            60 => FMODResult::ErrSubsounds,
+            61 => FMODResult::ErrSubsoundAllocated,
+            62 => FMODResult::ErrSubsoundCantMove,
+            63 => FMODResult::ErrTagNotFound,
+            64 => FMODResult::ErrTooManyChannels,
+            65 => FMODResult::ErrTruncated,
+            66 => FMODResult::ErrUnimplemented,
+            67 => FMODResult::ErrUnitialized,
+            68 => FMODResult::ErrUnsupported,
+            69 => FMODResult::ErrVersion,
+            70 => FMODResult::ErrEventAlreadyLoaded,
+            71 => FMODResult::ErrEventLiveUpdateBusy,
+            72 => FMODResult::ErrEventLiveUpdateMismatch,
+            73 => FMODResult::ErrEventLiveUpdateTimeout,
+            74 => FMODResult::ErrEventNotFound,
+            75 => FMODResult::ErrStudioUnitialized,
+            76 => FMODResult::ErrStudioNotLoaded,
+            77 => FMODResult::ErrInvalidString,
+            78 => FMODResult::ErrAlreadyLocked,
+            79 => FMODResult::ErrNotLocked,
+            80 => FMODResult::ErrRecordDisconnected,
+            81 => FMODResult::ErrTooManySamples,
+            _ => FMODResult::ErrUnknown,
+        }
+    }
+}
+
+// Used to create our unique JS classes for each distinct return type
+macro_rules! create_js_result {
+    ($type:ident, $value_0:ty) => {
+        #[wasm_bindgen]
+        #[derive(Clone, Debug)]
+        struct $type(i32, $value_0);
+
+        #[wasm_bindgen]
+        impl $type {
+            #[wasm_bindgen(constructor)]
+            pub fn new(fmod_result: i32, value_0: $value_0) -> Self {
+                Self(fmod_result, value_0)
+            }
+        }
+    };
+    ($type:ident, $value_0:ty, $value_1:ty) => {
+        #[wasm_bindgen]
+        #[derive(Clone, Debug)]
+        struct $type(i32, $value_0, $value_1);
+
+        #[wasm_bindgen]
+        impl $type {
+            #[wasm_bindgen(constructor)]
+            pub fn new(fmod_result: i32, value_0: $value_0, value_1: $value_1) -> Self {
+                Self(fmod_result, value_0, value_1)
+            }
+        }
+    };
+}
+
+// No type, just result
+#[wasm_bindgen]
+struct JSResult(i32);
+
+#[wasm_bindgen]
+impl JSResult {
+    #[wasm_bindgen(constructor)]
+    pub fn new(fmod_result: i32) -> Self {
+        Self(fmod_result)
+    }
+}
+
+// Generic ones
+create_js_result!(JsValueJSResult, JsValue);
+create_js_result!(JsValueVecJSResult, Vec<JsValue>);
+
+// Our custom stuff
+create_js_result!(Attributes3dJSResult, Attributes3d);
+create_js_result!(PlaybackStateJSResult, PlaybackState);
+
+// Primitives
+create_js_result!(I32JSResult, i32);
+create_js_result!(F32JSResult, f32);
+create_js_result!(BoolJSResult, bool);
+create_js_result!(StringJSResult, String);
+
+// Multiple primitive
+create_js_result!(F32F32JSResult, f32, f32);

--- a/wasm/wasmfmod.js
+++ b/wasm/wasmfmod.js
@@ -1,0 +1,324 @@
+///
+/// # Explanation of the glue code and rationale behind the style.
+/// 
+/// Glue code exists, because out arguments set a field named `val` for the
+/// given object. For the actual returns, they return a result enum. A
+/// JavaScript class with methods could've been used here, but I didn't use it 
+/// to make it parallel to C api, which also is used by libfmod. So, any
+/// function name here is same in C and in the inner calls of libfmod FFI
+/// bindings.
+///
+/// Functions can have three types of return, just the result, or a class of 2
+/// elements, where second element is the value, or class of 3 elements, where
+/// last two elements are values.
+///
+/// Then, the Rust side of this code checks whether result is OK or not and
+/// converts it into Result<T, E>. I made this choice because as far as I can
+/// understand currently sending Result<T, E> back from JS requires
+/// throw/catch. While I think maybe I could've written a code similar to
+/// generated code, it wouldn't be concise as this one. Plus, this style also
+/// matches the way libfmod handles it in the Rust side.
+///
+/// Initially, these result types were going to be objects, but unfortunately,
+/// only way to read those from rust side was to use serde with wasm-bindgen.
+/// As I didn't know the implications of this, I decided against it and instead
+/// created classes. Unfortunately, this caused multiple classes for different
+/// primitive & struct types. For opaque types, using JsValue was easiest and
+/// least cumbersome option.
+///
+/// Where it was needed to send buffers with length and *u8, &[u8] was used,
+/// as that is translated to JS typed arrays by the bindgen. While it differs
+/// from the C API, I think letting wasm-bindgen to handle it was better choice
+/// here, as input for FMOD Emscripten was already going to be a typed JS array.
+///
+/// Another change was made for functions that return size so one can allocate,
+/// it upfront. Doing this in the rust-side would require two calls and either,
+/// copying all that data and slicing it in the rust side, or doing the slicing
+/// via js_sys on JS Array and then iterate over it. So, path of least resist-
+/// ance was neither of those, so I decided to stray away from the API compat
+/// for that reason. This is only the case for JS side though, rust side of API
+/// matches libfmod 1:1.
+///
+/// Single line statements with results are set to a variable named result, then
+/// returned for the readibility purposes, due to the lack of type information.
+///
+/// All this is based on insights gathered from these sources:
+/// - https://www.fmod.com/docs/2.02/api/platforms-html5.html
+/// - https://www.fmod.com/docs/2.02/api/studio-api.html
+/// - https://rustwasm.github.io/docs/wasm-bindgen/introduction.html
+///
+///
+/// In theory, all this can be generated. Another thing is, this file currently
+/// only works for wasm-bindgen's no_modules target. I was initially using web
+/// target, but that creates modules and I didn't want to do the hassle of imp-
+/// orting FMOD and this file into created JS module by the wasm-bindgen. So,
+/// this file can be made so it works for both of those, by making wasm_bindgen
+/// imports optional and importing FMODModule. 
+/// 
+
+// FMODModule function that FMOD provides populates this object.
+const FMOD = {};
+
+// Called when Emscripten runtime has initialized
+FMOD.onRuntimeInitialized = () => {
+};
+// Called before FMOD runs, but after Emscripten runtime has initialized
+FMOD.preRun = () => {
+};
+
+// Populates FMOD
+FMODModule(FMOD);
+
+// Imports generated classes from wasm_bindgen global
+const {
+  // Structs
+  Vector,
+  Attributes3d,
+  // Typeless results
+  JSResult,
+  JsValueJSResult,
+  JsValueVecJSResult,
+  
+  // Typed results
+  Attributes3dJSResult,
+  PlaybackStateJSResult,
+  
+  // Typed primitive results
+  I32JSResult,
+  F32JSResult,
+  BoolJSResult,
+  StringJSResult,
+  
+  // Typed tuple primitive results
+  F32F32JSResult,
+} = wasm_bindgen;
+
+
+// Below are the bindings that wasm-bindgen calls.
+
+// Studio
+
+function Studio_System_Create() {
+  const studio = {};
+  const result = FMOD.Studio_System_Create(studio);
+  return new JsValueJSResult(result, studio.val);
+}
+function Studio_System_Initialize(
+  studio,
+  maxChannels,
+  studioFlags,
+  flags,
+  extraDriverData,
+) {
+  const result = studio.initialize(
+    maxChannels,
+    studioFlags,
+    flags,
+    extraDriverData,
+  );
+  return new JSResult(result);
+}
+function Studio_System_LoadBankMemory(studio, buffer, mode, flags) {
+  const bank = {};
+  const result = studio.loadBankMemory(
+    buffer,
+    buffer.length,
+    mode,
+    flags,
+    bank,
+  );
+  return new JsValueJSResult(result, bank.val);
+}
+function Studio_System_UnloadAll(studio) {
+  const result = studio.unloadAll();
+  return new JSResult(result);
+}
+function Studio_System_GetEvent(studio, path) {
+  const event = {};
+  const result = studio.getEvent(path, event);
+  return new JsValueJSResult(result, event.val);
+}
+function Studio_System_GetBus(studio, path) {
+  const bus = {};
+  const result = studio.getBus(path, bus);
+  return new JsValueJSResult(result, bus.val);
+}
+function Studio_System_SetParameterByName(
+  studio,
+  name,
+  value,
+  ignoreSeekSpeed
+) {
+  const result = studio.setParameterByName(name, value, ignoreSeekSpeed);
+  return new JSResult(result);
+}
+function Studio_System_SetListenerAttributes(
+  studio,
+  listener,
+  attributes,
+  attenuationPosition,
+) {
+  const result = studio.setListenerAttributes(
+    listener,
+    attributes,
+    attenuationPosition,
+  );
+  return new JSResult(result);
+}
+function Studio_System_Update(studio) {
+  const result = studio.update();
+  return new JSResult(result);
+}
+
+// Bank
+
+function Studio_Bank_GetEventList(bank, capacity) {
+  const array = {};
+  const count = {};
+  const result = bank.getEventList(array, capacity, count);
+  return new JsValueVecJSResult(result, array.val.slice(0, count.val));
+}
+function Studio_Bank_GetEventCount(bank) {
+  const count = {};
+  const result = bank.getEventCount(count);
+  return new I32JSResult(result, count.val);
+}
+
+// EventDescription
+
+function Studio_EventDescription_GetPath(eventDescription) {
+  const retrieved = {};
+  let result = eventDescription.getPath(null, 0, retrieved);
+  // 0 is OK
+  if (result !== 0) {
+    return new StringJSResult(result, null);
+  }
+  const path = {};
+  result = eventDescription.getPath(path, retrieved.val, retrieved);
+  return new StringJSResult(result, path.val);
+}
+function Studio_EventDescription_CreateInstance(eventDescription) {
+  const instance = {};
+  const result = eventDescription.createInstance(instance);
+  return new JsValueJSResult(result, instance.val);
+}
+function Studio_EventDescription_GetInstanceCount(eventDescription) {
+  const count = {};
+  const result = eventDescription.getInstanceCount(count);
+  return new I32JSResult(result, count.val);
+}
+
+// EventInstance
+
+function Studio_EventInstance_Start(eventInstance) {
+  const result = eventInstance.start();
+  return new JSResult(result);
+}
+function Studio_EventInstance_Release(eventInstance) {
+  const result = eventInstance.release();
+  return new JSResult(result);
+}
+function Studio_EventInstance_Get3DAttributes(eventInstance) {
+  const attributes = {};
+  const result = eventInstance.get3DAttributes(attributes);
+  // This one is a bit annoying
+  return new Attributes3dJSResult(result, new Attributes3d(
+    new Vector(attributes["position.x"], attributes["position.y"], attributes["position.z"]),
+    new Vector(attributes["velocity.x"], attributes["velocity.y"], attributes["velocity.z"]),
+    new Vector(attributes["forward.x"], attributes["forward.y"], attributes["forward.z"]),
+    new Vector(attributes["up.x"], attributes["up.y"], attributes["up.z"]),
+  ));
+}
+function Studio_EventInstance_Set3DAttributes(eventInstance, attributes) {
+  const result = eventInstance.set3DAttributes(attributes);
+  return new JSResult(result);
+}
+function Studio_EventInstance_SetPitch(eventInstance, pitch) {
+  const result = eventInstance.setPitch(pitch);
+  return new JSResult(result);
+}
+function Studio_EventInstance_GetPitch(eventInstance) {
+  const pitch = {};
+  const finalPitch = {};
+  const result = eventInstance.getPitch(pitch, finalPitch);
+  return new F32F32JSResult(result, pitch.val, finalPitch.val);
+}
+function Studio_EventInstance_SetProperty(eventInstance, index, value) {
+  const result = eventInstance.setProperty(index, value);
+  return new JSResult(result);
+}
+function Studio_EventInstance_GetProperty(eventInstance, index) {
+  // FMOD docs use the name value, so I used value.
+  //property would be better but imho.
+  const value = {};
+  const result = eventInstance.getProperty(index, value);
+  return new F32JSResult(result, value.val);
+}
+function Studio_EventInstance_SetTimelinePosition(eventInstance, position) {
+  const result = eventInstance.setTimelinePosition(position);
+  return new JSResult(result);
+}
+function Studio_EventInstance_GetTimelinePosition(eventInstance) {
+  const position = {};
+  const result = eventInstance.getTimelinePosition(position);
+  return new I32JSResult(result, position.val);
+}
+function Studio_EventInstance_SetVolume(eventInstance, volume) {
+  const result = eventInstance.setVolume(volume);
+  return new JSResult(result);
+}
+function Studio_EventInstance_GetVolume(eventInstance) {
+  const volume = {};
+  const finalVolume = {};
+  const result = eventInstance.getVolume(volume, finalVolume);
+  return new F32F32JSResult(result, volume.val, finalVolume.val);
+}
+function Studio_EventInstance_IsVirtual(eventInstance) {
+  const virtual = {};
+  const result = eventInstance.isVirtual(virtual);
+  return new BoolJSResult(result, virtual.val);
+}
+function Studio_EventInstance_GetParameterByName(eventInstance, name) {
+  const value = {};
+  const finalValue = {};
+  const result = eventInstance.getParameterByName(name, value, finalValue);
+  return new F32F32JSResult(result, value.val, finalValue.val);
+}
+function Studio_EventInstance_SetParameterByName(
+  eventInstance,
+  name,
+  value,
+  ignoreSeekSpeed,
+) {
+  const result = eventInstance.setParameterByName(
+    name,
+    value,
+    ignoreSeekSpeed,
+  );
+  return new JSResult(result);
+}
+function Studio_EventInstance_Stop(eventInstance, mode) {
+  const result = eventInstance.stop(mode);
+  return new JSResult(result);
+}
+function Studio_EventInstance_SetPaused(eventInstance, paused) {
+  const result = eventInstance.setPaused(paused);
+  return new JSResult(result);
+}
+function Studio_EventInstance_GetPaused(eventInstance) {
+  const paused = {};
+  const result = eventInstance.getPaused(paused);
+  return new BoolJSResult(result, paused.val);
+}
+function Studio_EventInstance_GetPlaybackState(eventInstance) {
+  const state = {};
+  const result = eventInstance.getPlaybackState(state);
+  return new PlaybackStateJSResult(result, state.val);
+}
+
+// Bus
+
+function Studio_Bus_SetMute(bus, mute) {
+  const result = bus.setMute(mute);
+  return new JSResult(result);
+}


### PR DESCRIPTION
There are notes in TEMP_README.md about setup etc.

Other than those, several highlights:
- As JsValue isn't Copy, structs with opaque values like Studio, EventInstance are not Copy unlike libfmod. It is possible to fix it, but I need to search the implications of it. So, left it on the table for now.
- Running it on browser requires interaction/click initiate the sound. This is a standard to avoid annoying unsolicited ads etc.
- The binary logs what it does via an agnostic logger macro, which logs to browser console when it works as WASM.
- Live update doesn't work, probably requires some amount of work with proxy servers and stuff.
- ``extra_driver_data`` argument provided during initialization probably doesn't work. I didn't test it because there were no obvious and easy way to test it. I assume it either needs to be initialized at Emscripten side, or at least on JS side. So, sending voidptr from Rust side is not the way to do it (which current code does).